### PR TITLE
#28: Add experiment naming guidance

### DIFF
--- a/docs/CMIP7/index.md
+++ b/docs/CMIP7/index.md
@@ -13,3 +13,4 @@ title: CMIP7 Guidance
 - [Guidance for ESGF node operators](guidance_for_esgf.md)
 - [Terms of use](terms_of_use.md)
 - [Data Request Software](https://github.com/CMIP-Data-Request/CMIP7_DReq_Software)
+- [Experiment naming guidance](https://zenodo.org/records/14929769)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ title: CMIP7 Guidance and Documentation
 - [Guidance for ESGF node operators](CMIP7/guidance_for_esgf.md)
 - [Terms of use](CMIP7/terms_of_use.md)
 - [Data Request Software](https://github.com/CMIP-Data-Request/CMIP7_DReq_Software)
+- [Experiment naming guidance](https://zenodo.org/records/14929769)
 
 ### CMIP6
 


### PR DESCRIPTION
Changes to link to Experiment guidance documentation on Zenodo.