### PR TITLE
remove broken links

### DIFF
--- a/docs/links.yml
+++ b/docs/links.yml
@@ -8,11 +8,11 @@ links:
   - title: "Essential Model Documentation"
     url: "https://emd.mipcvs.dev/docs/"
 
-  - title: "CVs Constants"
-    url: "https://constants.mipcvs.dev/docs/"
+  # - title: "CVs Constants"
+  #  url: "https://constants.mipcvs.dev/docs/"
 
-  - title: "CVs CMIP7"
-    url: "https://cmip7.mipcvs.dev/docs/"
+  # - title: "CVs CMIP7"
+  #   url: "https://cmip7.mipcvs.dev/docs/"
 
 
   # Categorized links


### PR DESCRIPTION
Commenting out broken links.

@wolfiex -- feel free to put these back in when they work. The constants one goes into an infinite loop of redirects appending "/docs" each time.