### PR TITLE
redirects to prevent broken links caused by capitalization in file names

### DIFF
--- a/src/mkdocs/mkdocs.yml
+++ b/src/mkdocs/mkdocs.yml
@@ -38,6 +38,16 @@ plugins:
       implicit_index: true
       tab_length: 2
 
+  - redirects:
+      redirect_maps:
+        '101_CMIP7/global_attributes.md': '101_CMIP7/Global_Attributes.md'
+        '101_CMIP7/branded_variables.md': '101_CMIP7/Branded_Variables.md'
+        '101_CMIP7/domain_names.md': '101_CMIP7/Domain_names.md'
+        '101_CMIP7/guidance_for_esgf.md': '101_CMIP7/Guidance_for_ESGF.md'
+        '101_CMIP7/guidance_for_mips.md': '101_CMIP7/Guidance_for_MIPs.md'
+        '101_CMIP7/guidance_for_modellers.md': '101_CMIP7/Guidance_for_modellers.md'
+        '101_CMIP7/guidance_for_users.md': '101_CMIP7/Guidance_for_users.md'
+
 # Hooks
 hooks:
   - hooks/generate_nav.py

--- a/src/mkdocs/requirements.txt
+++ b/src/mkdocs/requirements.txt
@@ -3,6 +3,7 @@ mkdocs>=1.5.0
 mkdocs-shadcn>=0.1.0
 mkdocs-gen-files>=0.5.0
 mkdocs-literate-nav>=0.6.0
+mkdocs-redirects>=1.2.2
 pymdown-extensions>=10.0
 pyyaml>=6.0
 # mike>=2.0.0  # Removed - simple deployment without versioning


### PR DESCRIPTION
Fix broken links using https://github.com/mkdocs/mkdocs-redirects as @matthew-mizielinski suggested in https://github.com/WCRP-CMIP/cmip7-guidance/pull/109 

If this solution doesn't cause any other issues then we should be able to retain the recent file name changes (capitalizations) and the old links from previous IPO emails (and wherever else they may have been used) should be ok. 

And, it shouldn't then be necessary to merge #109 (but that shouldn't break anything either)