### PR TITLE
update the redirects

### DIFF
--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -188,7 +188,7 @@ Data requirements are defined and discussed in the following documents:
 - [Reference "controlled vocabularies" (CVs) for CMIP7](https://github.com/WCRP-CMIP/CMIP7-CVs)
 - [Guidance on output grids](https://zenodo.org/records/15697025)
 - Requested atmospheric pressure levels are described in [Table 2 / Figure 2 of Dingley et al. 2025](https://egusphere.copernicus.org/preprints/2025/egusphere-2025-3189/)
-- [Guidance on time averaging (with masking)](../110_CMIP6/time_and_area_averaging.md) (CMIP6 guidance, to be reviewed).
+- [Guidance on time averaging (with masking)](../CMIP6/time_and_area_averaging.md) (CMIP6 guidance, to be reviewed).
 
 Additional metadata requirements are imposed on a variable by variable basis as specified in the Data Request.
 Many of these are recognized by CMOR (through input via the CMIP7 CMOR Tables), which will ensure compliance.

--- a/docs/Updates_for_Modellers.md
+++ b/docs/Updates_for_Modellers.md
@@ -331,7 +331,7 @@ limited content, while access to existing site content will be maintained in an 
 ### Accessing CMIP7 relevant information sources
 
 To ensure that modelling groups are able to access all services relevant to CMIP7 activities a list of domain names is being put together 
-[here](101_CMIP7/Domain_names.md). 
+[here](CMIP7/Domain_names.md). 
 This will initially include domain names for ESGF, the errata service and services relevant to the REF, but others will be added as they are collected.
 
 ----

--- a/src/mkdocs/mkdocs.yml
+++ b/src/mkdocs/mkdocs.yml
@@ -40,13 +40,13 @@ plugins:
 
   - redirects:
       redirect_maps:
-        '101_CMIP7/global_attributes.md': '101_CMIP7/Global_Attributes.md'
-        '101_CMIP7/branded_variables.md': '101_CMIP7/Branded_Variables.md'
-        '101_CMIP7/domain_names.md': '101_CMIP7/Domain_names.md'
-        '101_CMIP7/guidance_for_esgf.md': '101_CMIP7/Guidance_for_ESGF.md'
-        '101_CMIP7/guidance_for_mips.md': '101_CMIP7/Guidance_for_MIPs.md'
-        '101_CMIP7/guidance_for_modellers.md': '101_CMIP7/Guidance_for_modellers.md'
-        '101_CMIP7/guidance_for_users.md': '101_CMIP7/Guidance_for_users.md'
+        'CMIP7/global_attributes.md': 'CMIP7/Global_Attributes.md'
+        'CMIP7/branded_variables.md': 'CMIP7/Branded_Variables.md'
+        'CMIP7/domain_names.md': 'CMIP7/Domain_names.md'
+        'CMIP7/guidance_for_esgf.md': 'CMIP7/Guidance_for_ESGF.md'
+        'CMIP7/guidance_for_mips.md': 'CMIP7/Guidance_for_MIPs.md'
+        'CMIP7/guidance_for_modellers.md': 'CMIP7/Guidance_for_modellers.md'
+        'CMIP7/guidance_for_users.md': 'CMIP7/Guidance_for_users.md'
 
 # Hooks
 hooks:


### PR DESCRIPTION
Remove numeric prefix from redirects in mkdocs.yml.

https://github.com/WCRP-CMIP/cmip7-guidance/pull/110 that was already merged was done before https://github.com/WCRP-CMIP/cmip7-guidance/pull/111 and hence it included the numeric prefix in the redirect paths. Since https://github.com/WCRP-CMIP/cmip7-guidance/pull/111 removed the prefixes, the redirects need updating to remove the prefixes.