### PR TITLE
Add cloud info to user guidance

### DIFF
--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -224,7 +224,7 @@ The CMIP7 compound name used in the Data Request also includes each requested va
 
 For example, the equivalent of `Amon.tas` in CMIP6 would be  `atmos.tas_tavg-h2m-hxy-u.mon.GLB` in CMIP7.
 
-??? info "Understanding Data Request"
+??? info "Understanding the Data Request"
     The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. The latest version of the Data Request can be [viewed here][datarequest], and further guidance can be [found here](https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Guidance_for_modellers/#4-model-output-fields). 
 
 
@@ -324,7 +324,7 @@ First time using CMIP? Need a bit more help ? Check out these ressources:
 
 
 
-###### Document version: 2025-10-08
+###### Document version: 2026-04-08
  <!--  abbreviation -->
 *[CMIP7]: Coupled Model Intercomparison Project phase 7
 *[LLNL]: Lawrence Livermore National Laboratory

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -44,14 +44,15 @@ There are 3 options to access the data:
 
     While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
 
-
+    * links coming soon
 
 
     ??? info "Analysis-Ready Cloud-Optimized data"
 
-        Data hosted in the cloud can be very useful for users with fewer resources. Indeed, data can be streamed and the analysis can be done remotely close to the storage, instead of downloading it locally. For efficient analysis in the cloud, the data needs to be in an Analysis-Ready Cloud-Optimized (ARCO) format. Following the Pangeo / ESGF Cloud Data Working Group efforts for CMIP6,  there are community efforts underway to streamline ARCO access (e.g., [virtualizarr][[virtualizarr](https://virtualizarr.readthedocs.io/en/stable/)]) to lowering barriers to producing cloud-optimized data formats without having to rewrite the original data. Contributions are welcomed [here][virtual].
+        Data hosted in the cloud can be very useful for users with fewer resources. Indeed, data can be streamed and the analysis can be done remotely close to the storage, instead of downloading it locally. For efficient analysis in the cloud, the data needs to be in an Analysis-Ready Cloud-Optimized (ARCO) format. Following the Pangeo / ESGF Cloud Data Working Group efforts for CMIP6,  there are community efforts underway to streamline ARCO access (e.g., [virtualizarr][virtualizarr]), which will lower barriers to producing cloud-optimized data formats without having to rewrite the original data. Contributions are welcomed [here][virtual].
+
       
-For data access routes that do not involve official ESGF nodes, we encourage users to verify that the data used is the latest version, and cite the original sources appropriately. 
+For data access routes that do not involve official ESGF nodes, we encourage users to verify that the data used is the latest version, and cite the original sources appropriately (see below). 
 
 
 
@@ -115,7 +116,7 @@ To enable modelling groups and others who support CMIP7 to demonstrate its impac
 
 ###  Recommended
 
- 1. **Cite the CMIP literature**
+1. **Cite the CMIP literature**
 
     To provide more context, we recommend citing relevant articles. For example:
 
@@ -127,12 +128,12 @@ To enable modelling groups and others who support CMIP7 to demonstrate its impac
 
 In general, the [CMIP7 GMD special issue][GMDSpecialIssue] is a good place to look for relevant literature.
  
- 2. **Register your work.**
+2. **Register your work.**
 
     Register your work on the [CMIP7 Publication Hub][CMIPpubs] (coming soon). 
 
 
- 3. **Use the standard vocabularies**
+3. **Use the standard vocabularies**
 
     Where possible, we recommend using the CMIP7 standardized names as defined by the [controlled vocabularies (CVs)][cmipCvs] (see [Section 3](#3-cmip7-facets-and-their-documentation)) for terms such as the source (model) or experiment, in order to make references as clear and unambiguous as possible. However, if your audience requires different terms, then you should use those but we recommend keeping a mapping from the term your audience uses to the standardized name, again to ensure that references can be unambiguously resolved where needed. Refer to the collection of CMIP7 models as the “CMIP7 multi-model ensemble”.
     

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -44,14 +44,16 @@ There are 3 options to access the data:
 
     While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
 
-    * The [Pangeo / ESGF Cloud Data Working Group][pangeo] is working on providing cloud access for CMIP7 ARCO data. 
 
 
     For all non-ESGF data access routes, we encourage users to verify that the data used is the latest version. 
 
     ??? info "Analysis-Ready Cloud-Optimized data"
 
-        Data hosted in the cloud can be very useful for users with fewer ressources. Indeed, data can be streamed and the analysis can be done remotely close to the storage, instead of downloading it locally. For efficient analysis in the cloud, the data needs to be in an Analysis-Ready Cloud-Optimized (ARCO) format. The Pangeo / ESGF Cloud Data Working Group are working on tools (e.g., [virtualizarr][virtualizarr]) for this purpose. Contributions are welcomed [here][virtual].
+        Data hosted in the cloud can be very useful for users with fewer resources. Indeed, data can be streamed and the analysis can be done remotely close to the storage, instead of downloading it locally. For efficient analysis in the cloud, the data needs to be in an Analysis-Ready Cloud-Optimized (ARCO) format. Following the Pangeo / ESGF Cloud Data Working Group efforts for CMIP6,  there are community efforts underway to streamline ARCO access (e.g., [virtualizarr][[virtualizarr](https://virtualizarr.readthedocs.io/en/stable/)]) to lowering barriers to producing cloud-optimized data formats without having to rewrite the original data. Contributions are welcomed [here][virtual].
+      
+For data access routes that do not involve official ESGF nodes, we encourage users to verify that the data used is the latest version, and cite the original sources appropriately. 
+
 
 
 

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -46,7 +46,6 @@ There are 3 options to access the data:
 
 
 
-    For all non-ESGF data access routes, we encourage users to verify that the data used is the latest version. 
 
     ??? info "Analysis-Ready Cloud-Optimized data"
 

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -6,7 +6,7 @@ title: CMIP7 Guidance for Data Users
 # CMIP7 Guidance for Data Users
 
 
-This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to provide context and to redirect them to the proper resources to learn more.
+This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to provide context and to redirect them to more detailed resources to learn more.
 
 
 
@@ -17,7 +17,7 @@ CMIP7 model output is available through a distributed data archive developed and
 
 ??? info "Understanding ESGF Nodes"
 
-    ESGF is a collaboration of groups, agencies and institutions around the world, that are dedicated to the development and operation of a long-term system for the management, access and analysis of climate data. The ESGF architecture is based on a system of autonomous and distributed Nodes. Data is hosted on a collection of data nodes located at modelling centres or data centres across the world. Nodes exchange information about their data holdings and services, trust each other for registering users and establishing access control decisions. Data can be searched through index nodes that hold catalogues of what is available on the data node. The net result is that a user can use a web browser or rich desktop client, connect to any Node, and seamlessly find and access data throughout the federation. 
+    ESGF is a collaboration of groups, agencies and institutions around the world, that are dedicated to the development and operation of a long-term system for the management, access and analysis of climate data.  The ESGF architecture is based on a system of distributed Nodes.  Data is hosted on a collection of data nodes located at modelling centres or data centres across the world.  Data can be searched through index nodes that hold catalogues of what is available on the data node. The net result is that a user can use a web browser or rich desktop client, connect to any Node, and seamlessly find and access data throughout the federation. 
     
     It is possible for a node to be down, which can lead to data being unavailable for periods of time.
 
@@ -176,7 +176,7 @@ More information about the meaning of these facets is provided in the [global at
 * [Essential Model Documentation (EMD)][emd] (coming soon)
 
 
-The Essential Model Documentation (EMD) contains a high-level description intended to contain information on model formulation that can be easily compared between different models. EMD pages contain links to more in-depth model documentation for each source.
+The Essential Model Documentation (EMD) contains a high-level description intended to contain information on model formulation that can be easily compared between different models. The [EMD guidance pages][emd] contain links to more in-depth model documentation for each source.
 
 ??? info "Basic Concepts to Understand Variants"
     The source facet gives the name of the model and the variant facet represents each member of an ensemble for a given source. It can also be called the “ripf” identifier (“r” for realization, “i” for initialization, “p” for physics, and “f” for forcing).
@@ -204,19 +204,19 @@ The CMIP7 protocol and experiments are described in a [special issue][GMDSpecial
 
 
 ### 3.3. Variable
-* [List of variables][varlist] (coming soon)
+* [List of variables][varlist]
 * [Branded variable documentation](Branded_Variables.md)
 
-The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. In CMIP7, the concept of branded variable identifies the variables. Branded variables follows the template: 
+The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. The latest version of the Data Request can be [viewed here](https://bit.ly/CMIP7-DReq-latest), and further guidance can be [found here](https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Guidance_for_modellers/#4-model-output-fields). In CMIP7, the concept of branded variables has been introduced to make it easier to find the variables you want. Branded variables follow the template: 
 
 ```
 <branded_variable> 
-= <variable_id>_<branded_suffix>
+= <variable_id>_<branding_suffix>
 = <variable_id>_<temporal_label>-<vertical_label>-<horizontal_label>-<area_label>
 ```
 
-To uniquely identify variables, frequency and region are required together with the branded variable.
-The CMIP7 compound name also includes realm for ease of use:
+To uniquely identify requested variables, frequency and region are required together with the branded variable.
+The CMIP7 compound name used in the Data Request also includes each requested variable's primary realm, for ease of identifying variables associated with a realm:
 ```
 <compound_name> = <realm>.<branded_variable>.<frequency>.<region>
 ```
@@ -227,9 +227,9 @@ For example, the equivalent of `Amon.tas` in CMIP6 would be  `atmos.tas_tavg-h2m
 <!--TODO: maybe add more about Data Request. -->
 
 ### 3.4 Frequency
-* [List of frequencies][freqlist] (coming soon)
+* [List of frequencies][freqlist]
 
-Models report data on a variety of time steps. The [MIP table][varlist] defines the frequency with which requested variables in an experiment should be reported.
+Models report data on a variety of time steps. In CMIP6, MIP tables (aka CMOR tables) defined the frequency at which requested variables in an experiment should be reported (e.g., "Amon", "day"). In CMIP7 the frequency is specified in the Data Request for every requested variable and reported in netCDF files as a global attribute. The [CMOR tables for CMIP7](https://github.com/WCRP-CMIP/cmip7-cmor-tables) contain branded variables, are organized by realm, and no longer specify frequency.
 
 ??? info "Calendars and Time Handling"
 
@@ -383,8 +383,8 @@ First time using CMIP? Need a bit more help ? Check out these ressources:
 [cmipCvs]: https://github.com/WCRP-CMIP/CMIP7-CVs
 [DataRequestTeam]: https://wcrp-cmip.org/cmip-phases/cmip7/cmip7-data-request/
 [FeoC]: https://wcrp-cmip.org/cmip7-task-teams/fresh-eyes-on-cmip/
-[GlobalAttrs]: https://zenodo.org/records/17250297
-[grid]: https://zenodo.org/records/15697025
+[GlobalAttrs]: https://doi.org/10.5281/zenodo.17250296
+[grid]: https://doi.org/10.5281/zenodo.15697024
 [variableid]: https://airtable.com/apphMYhEwBJfd0bUK/shrYC888Qxf8gkvky/tblpo5L8maBIGlM1B/viwNNzrqK5oPL7zk2
 [dataReq]: https://egusphere.copernicus.org/preprints/2025/egusphere-2025-3189/
 
@@ -404,15 +404,15 @@ First time using CMIP? Need a bit more help ? Check out these ressources:
 
  <!-- unknown links -->
 [CMIPpubs]:  ?
-[varlist]:  ?
+[varlist]: https://cmip-data-request.github.io/cmip7-dreq-webview/latest/variables.html
 [experimentlist]:  ?
 [activitylist]:  ?
 [sourcelist]:  ?
 [gridlist]: ?
 [levellist]:  ?
-[freqlist]:  ?
+[freqlist]: https://cmip-data-request.github.io/cmip7-dreq-webview/latest/cmip7_frequency.html
 [maskavg]:  ?
-[emd]:  ?
+[emd]:  https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/
 [eld]: ?
 [gridreg]: ?
 

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -6,7 +6,7 @@ title: CMIP7 Guidance for Data Users
 # CMIP7 Guidance for Data Users
 
 
-This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to redirect them to the proper resources to learn more.
+This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to provide context and to redirect them to the proper resources to learn more.
 
 
 
@@ -45,13 +45,9 @@ There are 3 options to access the data:
     While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
 
     * The [Pangeo / ESGF Cloud Data Working Group][pangeo] is working on providing cloud access for CMIP7 ARCO data. Contributions are welcomed [here][virtual].
-    * MORE COMING SOON
 
 
     For all non-ESGF data access routes, we encourage users to verify that the data used is the latest version. 
-
-    !!! Info 
-        Contributions are invited to help virtualizing CMIP7 zarrs.
 
 
 ## 2.  Terms of use and citations requirements
@@ -304,9 +300,11 @@ Proposing erratum through the webform requires a contact email address. Once the
 
 ## 6. New to CMIP?
 
-First time using CMIP? Need a bit more help ? Check out the [Entry-Level Documentation][eld] (coming soon), put together by the [Fresh Eyes on CMIP][FeoC] group.
+First time using CMIP? Need a bit more help ? Check these ressources out:
 
-You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform]. (You need to register [here][register] first.)
+* [Entry-Level Documentation][eld] (coming soon), put together by the [Fresh Eyes on CMIP][FeoC] group.
+* [List of tools for using climate data][tools].
+* You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform]. (You need to register [here][register] first.)
 
 
 
@@ -361,6 +359,8 @@ You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform
 [altaccess]: http://bit.ly/CMIP-data-platform
 [disclaimer]: https://doi.org/10.5281/zenodo.18155119
 [virtual]: https://github.com/carbonplan/cmip7-virtualization
+[pangeo]: https://pangeo-data.github.io/pangeo-cmip6-cloud/
+[tools]: https://wcrp-cmip.org/tools/
 
  <!-- CMIP7 links -->
 [GMDSpecialIssue]: https://gmd.copernicus.org/articles/special_issue1315.html
@@ -388,7 +388,7 @@ You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform
 [levellist]: https://cmip6dr.github.io/Data_Request_Home/Documents/CMIP6_pressure_levels.pdf?id=88 
 [freqlist]: https://github.com/WCRP-CMIP/CMIP6_CVs/blob/main/CMIP6_frequency.json
 [maskavg]: https://wcrp-cmip.github.io/WGCM_Infrastructure_Panel/CMIP6/time_and_area_averaging.html -->
-[pangeo]: https://pangeo-data.github.io/pangeo-cmip6-cloud/
+
 
  <!-- unknown links -->
 [CMIPpubs]:  ?

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -315,7 +315,7 @@ Proposing erratum through the webform requires a contact email address. Once the
 
 ## 6. New to CMIP?
 
-First time using CMIP? Need a bit more help ? Check out these ressources:
+First time using CMIP? Need a bit more help ? Check out these resources:
 
 * [Entry-Level Documentation][eld] (coming soon), put together by the [Fresh Eyes on CMIP][FeoC] group.
 * [List of tools for using climate data][tools].

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -6,7 +6,7 @@ title: CMIP7 Guidance for Data Users
 # CMIP7 Guidance for Data Users
 
 
-This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to provide context and to redirect them to more detailed resources to learn more.
+This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to provide context and to redirect them to more detailed resources.
 
 
 
@@ -17,7 +17,7 @@ CMIP7 model output is available through a distributed data archive developed and
 
 ??? info "Understanding ESGF Nodes"
 
-    ESGF is a collaboration of groups, agencies and institutions around the world, that are dedicated to the development and operation of a long-term system for the management, access and analysis of climate data.  The ESGF architecture is based on a system of distributed Nodes.  Data is hosted on a collection of data nodes located at modelling centres or data centres across the world.  Data can be searched through index nodes that hold catalogues of what is available on the data node. The net result is that a user can use a web browser or rich desktop client, connect to any Node, and seamlessly find and access data throughout the federation. 
+    ESGF is a collaboration of groups, agencies and institutions around the world, that are dedicated to the development and operation of a long-term system for the management, access and analysis of climate data.  The ESGF architecture is based on a system of distributed Nodes.  Data is hosted on a collection of data nodes located at modelling centres or data centres across the world.  Data can be searched through index nodes that hold catalogues of what is available on the data nodes. The net result is that a user can use a web browser or rich desktop client, connect to any Node, and seamlessly find and access data throughout the federation. 
     
     It is possible for a node to be down, which can lead to data being unavailable for periods of time.
 
@@ -207,7 +207,7 @@ The CMIP7 protocol and experiments are described in a [special issue][GMDSpecial
 * [List of variables][varlist]
 * [Branded variable documentation](Branded_Variables.md)
 
-The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. The latest version of the Data Request can be [viewed here](https://bit.ly/CMIP7-DReq-latest), and further guidance can be [found here](https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Guidance_for_modellers/#4-model-output-fields). In CMIP7, the concept of branded variables has been introduced to make it easier to find the variables you want. Branded variables follow the template: 
+In CMIP7, the concept of branded variables has been introduced to make it easier to find the variables you want. Branded variables follow the template: 
 
 ```
 <branded_variable> 
@@ -224,12 +224,16 @@ The CMIP7 compound name used in the Data Request also includes each requested va
 
 For example, the equivalent of `Amon.tas` in CMIP6 would be  `atmos.tas_tavg-h2m-hxy-u.mon.GLB` in CMIP7.
 
-<!--TODO: maybe add more about Data Request. -->
+??? info "Understanding Data Request"
+    The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. The latest version of the Data Request can be [viewed here][datarequest], and further guidance can be [found here](https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Guidance_for_modellers/#4-model-output-fields). 
+
 
 ### 3.4 Frequency
 * [List of frequencies][freqlist]
 
-Models report data on a variety of time steps. In CMIP6, MIP tables (aka CMOR tables) defined the frequency at which requested variables in an experiment should be reported (e.g., "Amon", "day"). In CMIP7 the frequency is specified in the Data Request for every requested variable and reported in netCDF files as a global attribute. The [CMOR tables for CMIP7](https://github.com/WCRP-CMIP/cmip7-cmor-tables) contain branded variables, are organized by realm, and no longer specify frequency.
+Models report data on a variety of time steps. 
+
+In CMIP6, the definition of requested variables included the frequency in which it should be reported, through the table id (e.g., "Amon", "day"). In CMIP7, the  definition of the variables are independent of the frequency, which is specified separately for every requested variable.
 
 ??? info "Calendars and Time Handling"
 
@@ -260,7 +264,7 @@ Models report data on a variety of time steps. In CMIP6, MIP tables (aka CMOR ta
 
 ### 3.5 Grid
 * [List of grids][gridlist] (coming soon)
-* List of pressure levels: [Table 2 of Dingley et al. 2025][dataReq]
+* List of pressure levels: [Table 2 of Dingley et al. 2025][datareqpaperatm]
 * [CMIP7 Guidance on Grids][grid]
 
 Different climate models use a variety of different horizontal grids that are documented in the [grid registry][gridreg] (coming soon).
@@ -386,7 +390,9 @@ First time using CMIP? Need a bit more help ? Check out these ressources:
 [GlobalAttrs]: https://doi.org/10.5281/zenodo.17250296
 [grid]: https://doi.org/10.5281/zenodo.15697024
 [variableid]: https://airtable.com/apphMYhEwBJfd0bUK/shrYC888Qxf8gkvky/tblpo5L8maBIGlM1B/viwNNzrqK5oPL7zk2
-[dataReq]: https://egusphere.copernicus.org/preprints/2025/egusphere-2025-3189/
+[datareqpaperatm]: https://egusphere.copernicus.org/preprints/2025/egusphere-2025-3189/
+[datarequest]: https://bit.ly/CMIP7-DReq-latest
+[cmortablecmip7]: https://github.com/WCRP-CMIP/cmip7-cmor-tables
 
 
  <!-- TODO: all the links below need to be changed when the new version arrives. airtable ? -->

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -126,8 +126,9 @@ To enable modelling groups and others who support CMIP7 to demonstrate its impac
         <!--Maybe use experiment CV to get the right citation, once they have that information. -->
     * Model documentation papers associated the model(s) used
 
-In general, the [CMIP7 GMD special issue][GMDSpecialIssue] is a good place to look for relevant literature.
+    In general, the [CMIP7 GMD special issue][GMDSpecialIssue] is a good place to look for relevant literature.
  
+
 2. **Register your work.**
 
     Register your work on the [CMIP7 Publication Hub][CMIPpubs] (coming soon). 

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -347,20 +347,13 @@ First time using CMIP? Need a bit more help ? Check out these ressources:
 [metagridornl]: https://esgf-node.ornl.gov/search
 [metagridceda]: https://esgf-ui.ceda.ac.uk/search
 [esgpull]: https://esgf.github.io/esgf-download/
-[citemaws]: https://doi.org/10.5281/zenodo.2621084
 [Stockhause2017]: https://doi.org/10.5334/dsj-2017-030
-[gdatasetsearch]: https://toolbox.google.com/datasetsearch/
-[datacitecat]: https://search.datacite.org/works?query=prefix:10.22033
 [CMIPPanel]: https://www.wcrp-climate.org/wgcm-cmip/cmip-panel
 [cfConventionsPage]: http://cfconventions.org/
-[gov]: https://wcrp-cmip.org/cmip-governance/
-[wgcmSite]: https://www.wcrp-climate.org/wgcm-overview
-[wip]: https://wcrp-cmip.github.io/WGCM_Infrastructure_Panel
 [CMIPMips]: https://wcrp-cmip.org/mips/
 [platform]: https://github.com/orgs/Fresh-Eyes-on-CMIP/discussions
 [register]: https://github.com/Fresh-Eyes-on-CMIP/member-requests/issues/new?template=new_user.yml
 [ErrataService]: https://errata.ipsl.fr/static/index.html
-[CC BY 4.0]: https://creativecommons.org/licenses/by/4.0/
 [esmvaltool]: https://esmvaltool.org/
 [intakeesgf]: https://github.com/esgf2-us/intake-esgf
 [cmor]:https://cmor.llnl.gov/
@@ -393,6 +386,9 @@ First time using CMIP? Need a bit more help ? Check out these ressources:
 [datareqpaperatm]: https://egusphere.copernicus.org/preprints/2025/egusphere-2025-3189/
 [datarequest]: https://bit.ly/CMIP7-DReq-latest
 [cmortablecmip7]: https://github.com/WCRP-CMIP/cmip7-cmor-tables
+[varlist]: https://cmip-data-request.github.io/cmip7-dreq-webview/latest/variables.html
+[freqlist]: https://cmip-data-request.github.io/cmip7-dreq-webview/latest/cmip7_frequency.html
+[emd]:  https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/
 
 
  <!-- TODO: all the links below need to be changed when the new version arrives. airtable ? -->
@@ -410,17 +406,15 @@ First time using CMIP? Need a bit more help ? Check out these ressources:
 
  <!-- unknown links -->
 [CMIPpubs]:  ?
-[varlist]: https://cmip-data-request.github.io/cmip7-dreq-webview/latest/variables.html
 [experimentlist]:  ?
 [activitylist]:  ?
 [sourcelist]:  ?
 [gridlist]: ?
 [levellist]:  ?
-[freqlist]: https://cmip-data-request.github.io/cmip7-dreq-webview/latest/cmip7_frequency.html
 [maskavg]:  ?
-[emd]:  https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/
 [eld]: ?
 [gridreg]: ?
+
 
 
  <!-- note: only admonitions that show color with this theme are Info, Success, Warning, Danger -->

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -207,19 +207,21 @@ The CMIP7 protocol and experiments are described in a [special issue][GMDSpecial
 The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. In CMIP7, the concept of branded variable identifies the variables. Branded variables follows the template: 
 
 ```
-<brandedVariable> 
-= <variableRoot>_<brandedSuffix>
-= <variableRoot>_<temporalLabel>-<verticalLabel>-<horizontalLabel>-<areaLabel>
+<branded_variable> 
+= <variable_id>_<branded_suffix>
+= <variable_id>_<temporal_label>-<vertical_label>-<horizontal_label>-<area_label>
 ```
 
-Branded variables are independant of frequency and region. To fully identify a variable, you need the compound name:
+To uniquely identify variables, frequency and region are required together with the branded variable.
+The CMIP7 compound name also includes realm for ease of use:
 ```
-<compound_name> = <brandedVariable>.<frequency>.<region>
+<compound_name> = <realm>.<branded_variable>.<frequency>.<region>
 ```
 
-For example, the equivalent of `Amon.tas` in CMIP6 would be  `tas_tavg-h2m-hxy-u.mon.GLB` in CMIP7.
 
-<!--TODO: add more about Data Request. Not super clear to me how it can be useful to users yet.-->
+For example, the equivalent of `Amon.tas` in CMIP6 would be  `atmos.tas_tavg-h2m-hxy-u.mon.GLB` in CMIP7.
+
+<!--TODO: maybe add more about Data Request. -->
 
 ### 3.4 Frequency
 * [List of frequencies][freqlist] (coming soon)
@@ -306,7 +308,7 @@ Proposing erratum through the webform requires a contact email address. Once the
 
 ## 6. New to CMIP?
 
-First time using CMIP? Need a bit more help ? Check these ressources out:
+First time using CMIP? Need a bit more help ? Check out these ressources:
 
 * [Entry-Level Documentation][eld] (coming soon), put together by the [Fresh Eyes on CMIP][FeoC] group.
 * [List of tools for using climate data][tools].
@@ -367,7 +369,7 @@ First time using CMIP? Need a bit more help ? Check these ressources out:
 [virtual]: https://github.com/carbonplan/cmip7-virtualization
 [pangeo]: https://pangeo-data.github.io/pangeo-cmip6-cloud/
 [tools]: https://wcrp-cmip.org/tools/
-[virtualizar]: https://virtualizarr.readthedocs.io/en/stable/
+[virtualizarr]: https://virtualizarr.readthedocs.io/en/stable/
 
  <!-- CMIP7 links -->
 [GMDSpecialIssue]: https://gmd.copernicus.org/articles/special_issue1315.html

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -8,6 +8,8 @@ title: CMIP7 Guidance for Data Users
 
 This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to redirect them to the proper resources to learn more.
 
+
+
 ## 1.  Accessing CMIP7 data
 
 CMIP7 model output is available through a distributed data archive developed and operated by the Earth System Grid Federation (ESGF). The data are hosted on a collection of nodes located at centres across the world.
@@ -15,7 +17,9 @@ CMIP7 model output is available through a distributed data archive developed and
 
 ??? info "Understanding ESGF Nodes"
 
-    ESGF is a collaboration of groups, agencies and institutions around the world, that are dedicated to the development and operation of a long-term system for the management, access and analysis of climate data. The ESGF architecture is based on a system of autonomous and distributed Nodes. Data is hosted on a collection of nodes located at modelling centres or data centres across the world. Nodes exchange information about their data holdings and services, trust each other for registering users and establishing access control decisions. The net result is that a user can use a web browser or rich desktop client, connect to any Node, and seamlessly find and access data throughout the federation.
+    ESGF is a collaboration of groups, agencies and institutions around the world, that are dedicated to the development and operation of a long-term system for the management, access and analysis of climate data. The ESGF architecture is based on a system of autonomous and distributed Nodes. Data is hosted on a collection of data nodes located at modelling centres or data centres across the world. Nodes exchange information about their data holdings and services, trust each other for registering users and establishing access control decisions. Data can be searched through index nodes that hold catalogues of what is available on the data node. The net result is that a user can use a web browser or rich desktop client, connect to any Node, and seamlessly find and access data throughout the federation. 
+    
+    It is possible for a node to be down, which can lead to data being unavailable for periods of time.
 
     More documentation on CMIP nodes is available [here][nodes].
 
@@ -40,9 +44,14 @@ There are 3 options to access the data:
 
     While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
 
-    * COMING SOON
+    * The [Pangeo / ESGF Cloud Data Working Group][pangeo] is working on providing cloud access for CMIP7 ARCO data. Contributions are welcomed [here][virtual].
+    * MORE COMING SOON
+
 
     For all non-ESGF data access routes, we encourage users to verify that the data used is the latest version. 
+
+    !!! Info 
+        Contributions are invited to help virtualizing CMIP7 zarrs.
 
 
 ## 2.  Terms of use and citations requirements
@@ -147,18 +156,20 @@ CMIP7 datasets can be identified through a series of facets that represents key 
 * grid
 * version
 
-!!! tip inline end
+!!! Info
 
     Current advice from the CVs task team is to only access the CVs via [ESGVOC](https://esgf.github.io/esgf-vocab/). This will be subject to change in the future.
 
-More information about the meaning of these facets is provided in the [global attributes documentation][GlobalAttrs], with further guidance provided on the [Global Attributes page](Global_Attributes.md). The values associated with each facet are standardized through the [CVs][cmipCvs]. They are used to search the ESGF database and can be found in the global attributes of the data. This section provides helpful links and gives a bit more information on a few key facets. 
 
+
+More information about the meaning of these facets is provided in the [global attributes documentation][GlobalAttrs], with further guidance provided on the [Global Attributes page](Global_Attributes.md). The values associated with each facet are standardized through the [CVs][cmipCvs]. They are used to search the ESGF database and can be found in the global attributes of the data. This section provides helpful links and gives a bit more information on a few key facets. 
 
 
 
 ### 3.1.  Source and Variant
 * [List of models][sourcelist] (coming soon)
 * [Essential Model Documentation (EMD)][emd] (coming soon)
+
 
 The Essential Model Documentation (EMD) contains a high-level description intended to contain information on model formulation that can be easily compared between different models. EMD pages contain links to more in-depth model documentation for each source.
 
@@ -191,11 +202,21 @@ The CMIP7 protocol and experiments are described in a [special issue][GMDSpecial
 * [List of variables][varlist] (coming soon)
 * [Branded variable documentation](Branded_Variables.md)
 
-The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. In CMIP7, the concept of branded variable identifies the variables. It follows the template: 
+The variables produced in CMIP7 were recommended by the [CMIP7 Data Request task team][DataRequestTeam]. In CMIP7, the concept of branded variable identifies the variables. Branded variables follows the template: 
 
 ```
-<variableRootDD>_<temporalLabelDD>-<verticalLabelDD>-<horizontalLabelDD>-<areaLabelDD>
+<brandedVariable> 
+= <variableRoot>_<brandedSuffix>
+= <variableRoot>_<temporalLabel>-<verticalLabel>-<horizontalLabel>-<areaLabel>
 ```
+
+Branded variables are independant of frequency and region. To fully identify a variable, you need the compound name:
+```
+<compound_name> = <brandedVariable>.<frequency>.<region>
+```
+
+For example, the equivalent of `Amon.tas` in CMIP6 would be  `tas_tavg-h2m-hxy-u.mon.GLB` in CMIP7.
+
 <!--TODO: add more about Data Request. Not super clear to me how it can be useful to users yet.-->
 
 ### 3.4 Frequency
@@ -260,7 +281,7 @@ Essential features of CMORized data are :
     * One variable per file
 * Self-describing (all metadata needed to interpret the data are included in the file)
 * Consistent units and standard names following [CF conventions][cfConventionsPage]
-* [Standard chunking](guidance_for_modellers.md#5-model-output-requirements)
+* [Standard chunking](Guidance_for_modellers.md#5-model-output-requirements)
 
 
 
@@ -269,7 +290,7 @@ Essential features of CMORized data are :
 ## 5.  Reporting suspected errors
 
 
-!!! Warning inline end
+!!! Danger "Warning"
     The CMIP7 archive contains the output of scientific simulations of the past and potential future that are subject to multiple sources of error, ranging from errors in data handling, to errors in the representation of the real world in either the model, or the experimental setup for which the model was used. Different parts of the CMIP7 archive may be subject to differing levels of such errors, and users should be alert to these issues, and their potential consequences.
 
 Information about discovered issues of CMIP7 data is captured by the [Errata Service][ErrataService].
@@ -293,7 +314,6 @@ You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform
 ###### Document version: 2025-10-08
  <!--  abbreviation -->
 *[CMIP7]: Coupled Model Intercomparison Project phase 7
-*[ESGF]: Earth System Grid Federation
 *[LLNL]: Lawrence Livermore National Laboratory
 *[DKRZ]: Deutsches Klimarechenzentrum (German Climate Computation Centre)
 *[ORNL]: Oak Ridge National Laboratory
@@ -306,6 +326,7 @@ You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform
 *[DECK]: Diagnostic, Evaluation and Characterization of Klima
 *[AFT]: Assessment Fast Track
 *[CMOR]: Climate Model Output Rewriter
+*[ARCO]: Analysis-Ready Cloud-Optimized
 
  <!-- valid general links -->
 [metagridllnl]: https://aims2.llnl.gov/search/
@@ -339,6 +360,7 @@ You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform
 [cmcc]: https://esgf-ui.cmcc.it/esgf-dashboard-ui/index.html
 [altaccess]: http://bit.ly/CMIP-data-platform
 [disclaimer]: https://doi.org/10.5281/zenodo.18155119
+[virtual]: https://github.com/carbonplan/cmip7-virtualization
 
  <!-- CMIP7 links -->
 [GMDSpecialIssue]: https://gmd.copernicus.org/articles/special_issue1315.html
@@ -366,7 +388,7 @@ You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform
 [levellist]: https://cmip6dr.github.io/Data_Request_Home/Documents/CMIP6_pressure_levels.pdf?id=88 
 [freqlist]: https://github.com/WCRP-CMIP/CMIP6_CVs/blob/main/CMIP6_frequency.json
 [maskavg]: https://wcrp-cmip.github.io/WGCM_Infrastructure_Panel/CMIP6/time_and_area_averaging.html -->
-
+[pangeo]: https://pangeo-data.github.io/pangeo-cmip6-cloud/
 
  <!-- unknown links -->
 [CMIPpubs]:  ?
@@ -382,3 +404,5 @@ You have a more specific question ? Ask it on the [Fresh Eyes Platform][platform
 [eld]: ?
 [gridreg]: ?
 
+
+ <!-- note: only admonitions that show color with this theme are Info, Success, Warning, Danger -->

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -42,12 +42,18 @@ There are 3 options to access the data:
 
 3. **Alternative Access Platforms**
 
-    While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Some of this data is hosted in the cloud, which can allow for streaming of the data instead of downloading.  Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
+    While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
 
-    * The [Pangeo / ESGF Cloud Data Working Group][pangeo] is working on providing cloud access for CMIP7 ARCO data. Contributions are welcomed [here][virtual].
+    * The [Pangeo / ESGF Cloud Data Working Group][pangeo] is working on providing cloud access for CMIP7 ARCO data. 
 
 
     For all non-ESGF data access routes, we encourage users to verify that the data used is the latest version. 
+
+    ??? info "Analysis-Ready Cloud-Optimized data"
+
+        Data hosted in the cloud can be very useful for users with fewer ressources. Indeed, data can be streamed and the analysis can be done remotely close to the storage, instead of downloading it locally. For efficient analysis in the cloud, the data needs to be in an Analysis-Ready Cloud-Optimized (ARCO) format. The Pangeo / ESGF Cloud Data Working Group are working on tools (e.g., [virtualizarr][virtualizarr]) for this purpose. Contributions are welcomed [here][virtual].
+
+
 
 
 ## 2.  Terms of use and citations requirements
@@ -361,6 +367,7 @@ First time using CMIP? Need a bit more help ? Check these ressources out:
 [virtual]: https://github.com/carbonplan/cmip7-virtualization
 [pangeo]: https://pangeo-data.github.io/pangeo-cmip6-cloud/
 [tools]: https://wcrp-cmip.org/tools/
+[virtualizar]: https://virtualizarr.readthedocs.io/en/stable/
 
  <!-- CMIP7 links -->
 [GMDSpecialIssue]: https://gmd.copernicus.org/articles/special_issue1315.html

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -42,7 +42,7 @@ There are 3 options to access the data:
 
 3. **Alternative Access Platforms**
 
-    While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
+    While all published CMIP7 data is available from ESGF, some of it is additionally hosted in non-ESGF storage facilities. Some of this data is hosted in the cloud, which can allow for streaming of the data instead of downloading.  Below are links to some of these replicas. If you know of another place CMIP data is currently being stored, please submit [this form][altaccess] to let us and the community know!
 
     * The [Pangeo / ESGF Cloud Data Working Group][pangeo] is working on providing cloud access for CMIP7 ARCO data. Contributions are welcomed [here][virtual].
 

--- a/src/mkdocs/mkdocs.yml
+++ b/src/mkdocs/mkdocs.yml
@@ -65,6 +65,7 @@ extra_javascript:
   - https://unpkg.com/mermaid@10/dist/mermaid.min.js
 
 markdown_extensions:
+  - abbr #TODO: check that it is okay to add this
   - admonition
   - attr_list
   - def_list


### PR DESCRIPTION
Request from Matt to add info from Aparna's workshop slides

I have added some text on the upcoming efforts and contribution invitation in section 1.3.

@aradhakrishnanGFDL let me know your thoughts on this and if you wanted to add more.


I also fixed a few issues of formating on the page that came with the new theme. I added back the abbr markdown_extensions. It allows to define acronyms when hovering over a word. It seems like it disapeared from the mkdows.yml in the reformating of the website. @wolfiex let me know if it should not be added back and if I should just remove my definitions.