### PR TITLE
update modellers guidance to say latest CMOR should be used

### DIFF
--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -229,7 +229,7 @@ update to this section of the documentation.
 CMOR, the `Climate Model Output Rewriter`, is a library written in C with interfaces for both Fortran and Python, with the aim of enforcing correct data and metadata structures for projects such as CMIP, which are now used widely across many projects.
 CMOR is maintained by PCMDI on [github](https://github.com/PCMDI/cmor) and is available for installation via [conda](https://anaconda.org/conda-forge/cmor) and has documentation [here](https://cmor.llnl.gov/).
 For CMIP7, the CMOR library has been updated in line with the changes to the [CMIP7 Global Attributes][global-attributes-latest]. 
-Data producers should update to version [v3.13](https://cmor.llnl.gov/news/2025/10/14/cmor3/) of CMOR to gain access to the necessary changes.
+Data producers should update to the [latest version of CMOR](https://github.com/PCMDI/cmor/releases) to gain access to the necessary changes.
 
 The CMOR PrePARE tool, used for quality checking in CMIP6, has been retired and data producers should refer to section 7 below for guidance on the new quality control tool, `esgf-qc`.
 


### PR DESCRIPTION
- min version is no longer 3.13
- the min version for CMIP7 production should be stated in the guidance once this is known (3.14.2 anticipated) 