### PR TITLE
Update docs-in-progress banner

### DIFF
--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -229,7 +229,7 @@ update to this section of the documentation.
 CMOR, the `Climate Model Output Rewriter`, is a library written in C with interfaces for both Fortran and Python, with the aim of enforcing correct data and metadata structures for projects such as CMIP, which are now used widely across many projects.
 CMOR is maintained by PCMDI on [github](https://github.com/PCMDI/cmor) and is available for installation via [conda](https://anaconda.org/conda-forge/cmor) and has documentation [here](https://cmor.llnl.gov/).
 For CMIP7, the CMOR library has been updated in line with the changes to the [CMIP7 Global Attributes][global-attributes-latest]. 
-Data producers should update to the [latest version of CMOR](https://github.com/PCMDI/cmor/releases) to gain access to the necessary changes.
+The **minimum CMOR version** required for CMIP7 production is [CMOR 3.14.2](https://github.com/PCMDI/cmor/releases/3.14.2).
 
 The CMOR PrePARE tool, used for quality checking in CMIP6, has been retired and data producers should refer to section 7 below for guidance on the new quality control tool, `esgf-qc`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ title: CMIP7 Guidance and Documentation
 !!! tip "Documentation in progress: "
     Updates to these pages will be made when new developments occur, to improve the documentation, and in response to user feedback (to contribute please [see here](#development-of-this-documentation)).
     
-    ⚠️ To use the **search function**, please use the [mirrored version of the site](https://guidance.mipcvs.dev/) instead of the [github.io version](https://wcrp-cmip.github.io/cmip7-guidance/).
+    ⚠️ To use the **search function**, please use the [mirrored version of the site](https://guidance.mipcvs.dev/) instead of the [github.io version](https://wcrp-cmip.github.io/cmip7-guidance/). This is a bug that will be corrected shortly.
 
 
 ## Guidance documents

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,10 @@ title: CMIP7 Guidance and Documentation
 
 # CMIP7 Guidance and Documentation
 
-!!! tip "Documentation in progress"
-
-    The contents of the pages are currently in development and will change. 
+!!! tip "Documentation in progress: "
+    Updates to these pages will be made when new developments occur, to improve the documentation, and in response to user feedback (to contribute please [see here](#development-of-this-documentation)).
+    
+    ⚠️ To use the **search function**, please use the [mirrored version of the site](https://guidance.mipcvs.dev/) instead of the [github.io version](https://wcrp-cmip.github.io/cmip7-guidance/).
 
 
 ## Guidance documents


### PR DESCRIPTION
- update the "doc in progress" warning on front page
- mention on it that search works at the mirror site but not github.io one currently (hopefully to be fixed soon!)
- specify minimum CMOR version for CMIP7 production as 3.14.2