### PR TITLE
Point to CMIP 2026 slides

### DIFF
--- a/docs/CMIP7/Domain_names.md
+++ b/docs/CMIP7/Domain_names.md
@@ -6,14 +6,14 @@ title: Domain names relevant to CMIP7 activities
 # Domain names relevant to CMIP7 activities
 
 The following domains and URLs are relevant to CMIP7 activities and may be useful to ensure that 
-institutional fire walls allow access.
+institutional firewalls allow access.
 
 To update this list please raise an issue (pull requests welcome) via [github](https://github.com/WCRP-CMIP/cmip7-guidance/).
 
 
 | Service | Domains |
 | --- | --- |
-| Errata | `errata.ipsl.fr` |
+| Errata | `errata.esgf.io` |
 | Errata Documentation | `ipsl.gitbook.io` |
 | CMIP6 Citation service | `www.wdc-climate.de` |
 | PID / Handle service | `handle-esgf.dkrz.de` |

--- a/docs/CMIP7/Guidance_for_ESGF.md
+++ b/docs/CMIP7/Guidance_for_ESGF.md
@@ -10,6 +10,7 @@ title: CMIP7 Participation Guidance for Data Managers
     The contents of the pages are currently in development.
     They will updated when ESGF-NG (Next Generation ESGF) is available for CMIP7 data publication.
     [See here](https://wcrp-cmip.org/esgf-information/) for previous announcements about ESGF changes.
+    A brief overview of ESGF-NG is given in the slides from [CMIP 2026 workshop WIP session](https://zenodo.org/records/18934629) (slides 22-27).
 
 
 ## 1. Installation and configuration

--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -94,7 +94,7 @@ of the overall design and scientific strategy provided in the lead article of th
 
 The forcings to be used for each experiment can be found at [experiment set up and forcings](./Experiment_set_up_and_Forcings/index.md).
 
-## 4.  Model output fields
+## 4.  Model output fields (data request)
 
 The [CMIP7 Data Request](https://wcrp-cmip.org/cmip-phases/cmip7/cmip7-data-request/) specifies the list of model output variables that should be saved from each of the CMIP7 experiments. 
 Find the [latest Data Request release here](https://wcrp-cmip.org/cmip7-data-request-latest).
@@ -106,9 +106,9 @@ These Opportunities were developed through a wide community consultation, leadin
 
     Key new features of the CMIP7 Data Request include:
 
-    - Use of **Opportunities** to document scientific objectives
+    - Use of **Opportunities** to document scientific objectives linked to variables and experiments
     - The three-part structure, with **Core** denoting a relatively small number of highest-priority variables
-    - Access via the online **Airtable** [web browser interface](https://bit.ly/CMIP7-DReq-latest) as well as a [python API](https://github.com/CMIP-Data-Request/CMIP7_DReq_software) for programmatic use
+    - Access via the online [Airtable interface](https://bit.ly/CMIP7-DReq-latest), [web viewer](https://cmip-data-request.github.io/cmip7-dreq-webview/latest), and a [python API](https://github.com/CMIP-Data-Request/CMIP7_DReq_software) for programmatic use
 
     These features are explained in more detail below.
 

--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -54,6 +54,11 @@ provided as early as possible):
   service is available in the 
   [Errata Service Documentation](https://ipsl.gitbook.io/esgf-errata-service).
 
+
+!!! info "Data production overview:"
+    Key steps for data preparation and publication readiness are outlined in the slides from [CMIP 2026 workshop WIP session](https://zenodo.org/records/18934629) (slides 30-36).
+
+
 ## 2.  Experiment Design
 
 The CMIP7 protocol and experiments are described in a [special issue of Geoscientific Model Development](https://gmd.copernicus.org/articles/special_issue1315.html) with an overview 

--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -47,7 +47,7 @@ provided as early as possible):
   further information will be provided in due course.
 
 * Correct published data when errors are discovered. Errors should be documented using the
-  [ESGF Errata Service](https://errata.ipsl.fr/) before further action is taken, e.g. retraction
+  [ESGF Errata Service][errata-service] before further action is taken, e.g. retraction
   and publication of replacement datasets.  Please note that the Errata Service supports 
   [user proposed issues](https://ipsl.gitbook.io/esgf-errata-service/errata-service-web-pages/propose-an-issue-through-webforms),
   which are moderated and passed to modelling groups as required. Further information about the
@@ -376,7 +376,7 @@ The [Earth System Grid Federation (ESGF)](https://esgf.github.io/) will facilita
 Data producers should note several key points:
 
 - **Data compliance checking**: [Quality Control (QC) checks](#7-software-for-checking-output) will be required to check that data is in conformance with output requirements outlined in the sections above.
-- **Correcting errors**: when errors in published data are discovered, they should be documented using the [ESGF Errata Service](https://errata.ipsl.fr/), and the erroneous datasets retracted. Corrected datasets should be published using an updated dataset version identifier.
+- **Correcting errors**: when errors in published data are discovered, they should be documented using the [ESGF Errata Service][errata-service], and the erroneous datasets retracted. Corrected datasets should be published using an updated dataset version identifier.
 - **Replication**: Some data nodes plan to replicate some of the data published by other nodes. This will provide some redundancy protecting against loss of at least some of the data in the event of a catastrophic storage failure at one node. It will also provide a backup source of data when one node is temporarily offline. Not all data will be replicated, so it is recommended that modeling groups retain a backup copy of their model output.
 - **Long-term archival**: A “snapshot” of CMIP7 data as it exists at the time of a deadline imposed by the IPCC’s 7th Assessment Report (IPCC-AR7) will be archived at the [IPCC Data Distribution Centre (IPCC DDC)](https://www.ipcc-data.org/).
 
@@ -410,7 +410,8 @@ The EMD content is stored in GitHub (in JSON files), and may be edited at any ti
 #### EMD structure
 
 The full EMD specification, which contains examples of filled-out EMD entries for model components and grids, may be found at:
-🗣️ [https://doi.org/10.5281/zenodo.15439551](https://doi.org/10.5281/zenodo.15439551)
+<!-- 🗣️ [https://doi.org/10.5281/zenodo.15439551](https://doi.org/10.5281/zenodo.15439551) -->
+🗣️ <https://doi.org/10.5281/zenodo.15439551>
 
 Each question asked in the online EMD creation form is accompanied by the relevant guidance, so reference to the full EMD specification should not generally be necessary during the creation process.
 
@@ -451,3 +452,4 @@ The mission, rationale and Terms of Reference for the WIP can be found
 <!-- links for referencing -->
 [global-attributes-latest]: https://doi.org/10.5281/zenodo.17250296
 [grids-guidance-latest]: https://doi.org/10.5281/zenodo.15697024
+[errata-service]: https://errata.esgf.io/

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -8,6 +8,8 @@ title: CMIP7 Guidance for Data Users
 
 This page is designed to inform users of climate model outputs on key CMIP7 concepts and tools. It is a landing page to provide context and to redirect them to more detailed resources.
 
+!!! info ""
+    An overview of **how to access and use CMIP data** is given in the slides from [CMIP 2026 workshop WIP session](https://zenodo.org/records/18934629) (slides 3-20).
 
 
 ## 1.  Accessing CMIP7 data

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -353,7 +353,7 @@ First time using CMIP? Need a bit more help ? Check out these resources:
 [CMIPMips]: https://wcrp-cmip.org/mips/
 [platform]: https://github.com/orgs/Fresh-Eyes-on-CMIP/discussions
 [register]: https://github.com/Fresh-Eyes-on-CMIP/member-requests/issues/new?template=new_user.yml
-[ErrataService]: https://errata.ipsl.fr/static/index.html
+[ErrataService]: https://errata.esgf.io/
 [esmvaltool]: https://esmvaltool.org/
 [intakeesgf]: https://github.com/esgf2-us/intake-esgf
 [cmor]:https://cmor.llnl.gov/

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -382,7 +382,6 @@ First time using CMIP? Need a bit more help ? Check out these resources:
 [FeoC]: https://wcrp-cmip.org/cmip7-task-teams/fresh-eyes-on-cmip/
 [GlobalAttrs]: https://doi.org/10.5281/zenodo.17250296
 [grid]: https://doi.org/10.5281/zenodo.15697024
-[variableid]: https://airtable.com/apphMYhEwBJfd0bUK/shrYC888Qxf8gkvky/tblpo5L8maBIGlM1B/viwNNzrqK5oPL7zk2
 [datareqpaperatm]: https://egusphere.copernicus.org/preprints/2025/egusphere-2025-3189/
 [datarequest]: https://bit.ly/CMIP7-DReq-latest
 [cmortablecmip7]: https://github.com/WCRP-CMIP/cmip7-cmor-tables
@@ -391,10 +390,9 @@ First time using CMIP? Need a bit more help ? Check out these resources:
 [emd]:  https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/
 
 
- <!-- TODO: all the links below need to be changed when the new version arrives. airtable ? -->
+ <!-- TODO: all the links below need to be changed when the new version arrives. -->
  <!-- CMIP6 links -->
  <!--[CMIPpubs]: https://cmip-publications.llnl.gov/view/CMIP6/  
-[varlist]: https://airtable.com/apphXCUgASIeT6jCz/shrFnB7BtupFo1Y1e/tblqMgEiHxBJbwm2x
 [experimentlist]: https://wcrp-cmip.github.io/CMIP6_CVs/docs/CMIP6_experiment_id.html
 [activitylist]: https://github.com/WCRP-CMIP/CMIP6_CVs/blob/master/CMIP6_activity_id.json
 [sourcelist]: https://wcrp-cmip.github.io/CMIP6_CVs/docs/CMIP6_source_id.html 


### PR DESCRIPTION
Added links to relevant slides from CMIP 2026 workshop WIP session to the modellers, users & ESGF guidance pages. 

Also updated Errata service link to new official one `errata.esgf.io`, and very minor tweaks to DR section in modellers guidance.