### PR TITLE
Suspend experiment id registration form

### DIFF
--- a/docs/CMIP7/cv_registration.md
+++ b/docs/CMIP7/cv_registration.md
@@ -15,7 +15,7 @@ CMIP7 uses **Controlled Vocabularies (CVs)** to ensure consistency across all pa
 
 - Your **institution** (organisation)
 - Your **model** (source_id)
-- Any new **experiments** (if applicable)
+- Any new **experiments** (if applicable) 🛑 *Process suspended temporarily, should return end May 2026* 🛑
 - **Model documentation** (EMD) components
 
 Registration is done through **GitHub issue forms** - no Git expertise required.
@@ -61,12 +61,14 @@ Register your institution before registering a model.
 
 For new experiments not already in the CV.
 
-**Repository**: [CMIP7-CVs](https://github.com/WCRP-CMIP/CMIP7-CVs/issues)
+🛑 *Process suspended temporarily, should return end May 2026* 🛑
 
+**Repository**: [CMIP7-CVs](https://github.com/WCRP-CMIP/CMIP7-CVs/issues)
+<!--
 | Form | Link |
 |------|------|
 | Experiment | [Register experiment](https://github.com/WCRP-CMIP/CMIP7-CVs/issues/new?template=experiment.yml) |
-
+--!>
 ---
 
 ### 2.4 Essential Model Documentation (EMD)


### PR DESCRIPTION
This is a temporary change to allow CVs to consolidate the experiment definitions and ensure that the esgvoc branch has all experiments that have been registered at CMIP7_CVs. Once that is complete and CVs TT have confirmed the new process this change should be reversed or the pages updated accordingly.