### PR TITLE
Update domains whitelist

### DIFF
--- a/docs/CMIP7/Domain_names.md
+++ b/docs/CMIP7/Domain_names.md
@@ -24,6 +24,6 @@ To update this list please raise an issue (pull requests welcome) via [github](h
 | CEDA ESGF Metagrid | `esgf-ui.ceda.ac.uk` |
 | DKRZ ESGF Metagrid | `esgf-metagrid.cloud.dkrz.de` |
 | ESGF webpages | `*.esgf.io` |
+| CMIP7 guidance sites | `*.mipcvs.dev` |
 
-Last update Apr 2026
-
+Last update May 2026

--- a/docs/CMIP7/index.md
+++ b/docs/CMIP7/index.md
@@ -8,6 +8,7 @@ title: CMIP7 Guidance
 
 - [General Guidance](General_Guidance.md)
 - [Updates for modelling groups](../Updates_for_Modellers.md)
+- [Updates for Users](../Updates_for_users.md)
 - [Global Attributes](Global_Attributes.md)
 - [Data Specifications Versioning](data_specs_version.md)
 - [CV Registration Guide](cv_registration.md)

--- a/docs/Updates_for_Users.md
+++ b/docs/Updates_for_Users.md
@@ -6,4 +6,8 @@ title: CMIP7 Updates for users
 # Updates for data users
 
 This page will be updated with information of interest to users of CMIP7 data that the CMIP IPO has communicated by email (most recent at top).
+
+To sign up for the CMIP Community News mailing list please visit <https://wcrp-cmip.org/cmip-mailing-lists/>.
+
+
 ---

--- a/docs/Updates_for_Users.md
+++ b/docs/Updates_for_Users.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: CMIP7 Updates for users
+---
+
+# Updates for data users
+
+This page will be updated with information of interest to users of CMIP7 data that the CMIP IPO has communicated by email (most recent at top).
+---

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ title: CMIP7 Guidance and Documentation
 
 - [General Guidance](CMIP7/General_Guidance.md)
 - [Updates for modelling groups](Updates_for_Modellers.md)
+- [Updates for Users](Updates_for_Users.md)
 - [Global Attributes](CMIP7/Global_Attributes.md)
 - [Branded Variables](CMIP7/Branded_Variables.md)
 - [CV Registration](CMIP7/cv_registration.md)


### PR DESCRIPTION
Add *.mipcvs.dev to domains whitelist to cover these sites:

https://guidance.mipcvs.dev/
(alternate URL for main CMIP7 guidance site)

https://emd.mipcvs.dev/docs/
(EMD documentation)
