### PR TITLE
add mipcvs.dev sites to domains whitelist

### DIFF
--- a/docs/CMIP7/Domain_names.md
+++ b/docs/CMIP7/Domain_names.md
@@ -23,7 +23,7 @@ To update this list please raise an issue (pull requests welcome) via [github](h
 | ORNL ESGF Metagrid | `esgf-node.ornl.gov` |
 | CEDA ESGF Metagrid | `esgf-ui.ceda.ac.uk` |
 | DKRZ ESGF Metagrid | `esgf-metagrid.cloud.dkrz.de` |
-| ESGF webpages | `*.esgf.io` |
+| CMIP7 guidance sites | `*.mipcvs.dev` |
 
-Last update Apr 2026
+Last update May 2026
 

--- a/docs/CMIP7/Domain_names.md
+++ b/docs/CMIP7/Domain_names.md
@@ -23,6 +23,7 @@ To update this list please raise an issue (pull requests welcome) via [github](h
 | ORNL ESGF Metagrid | `esgf-node.ornl.gov` |
 | CEDA ESGF Metagrid | `esgf-ui.ceda.ac.uk` |
 | DKRZ ESGF Metagrid | `esgf-metagrid.cloud.dkrz.de` |
+| ESGF webpages | `*.esgf.io` |
 | CMIP7 guidance sites | `*.mipcvs.dev` |
 
 Last update May 2026


### PR DESCRIPTION
To cover these sites:

https://guidance.mipcvs.dev/
(alternate URL for main CMIP7 guidance site)

https://emd.mipcvs.dev/docs/
(EMD documentation)