### PR TITLE
Reactivate latex rendering

### DIFF
--- a/src/mkdocs/mkdocs.yml
+++ b/src/mkdocs/mkdocs.yml
@@ -14,6 +14,8 @@ use_directory_urls: true  # Creates clean URLs like /page/ instead of /page.html
 theme:
   name: shadcn
   custom_dir: overrides
+  # Must be a dict, not null to avoid a bug in shadcn katex
+  katex_options: {}
   palette:
     primary: teal
     accent: teal

--- a/src/mkdocs/mkdocs.yml
+++ b/src/mkdocs/mkdocs.yml
@@ -80,8 +80,8 @@ markdown_extensions:
       anchor_linenums: true
       css_class: codehilite
   - pymdownx.inlinehilite
-  # - pymdownx.arithmatex:
-  #     generic: true
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
Fixes rendering of the 1pctCO2 page, compare the equations in the two pages below

- deployed: https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Experiment_set_up_and_Forcings/1pctco2/#data-described-on-other-experiment-pages-with-modifications-you-have-to-make
- this branch: https://add-tex-rendering.cmip7-guidance.pages.dev/CMIP7/Experiment_set_up_and_Forcings/1pctco2/#data-described-on-other-experiment-pages-with-modifications-you-have-to-make