### PR TITLE
Add CV registration page links on other pages

### DIFF
--- a/docs/CMIP7/General_Guidance.md
+++ b/docs/CMIP7/General_Guidance.md
@@ -20,3 +20,8 @@ A separate GMD-ESSD inter-journal special issue [“(CMIP7) forcings and inputs 
 
 The CMIP Panel is aware of concern regarding the pace of the review process for anticipated CMIP7 Assessment Fast Track analysis papers. Although these papers are not suitable for inclusion in the CMIP7 special issues, the Panel has raised the issue with the WCRP Joint Scientific Committee.
 
+## CMIP Community News mailing list
+
+The CMIP Community News mailing list is the primary list for sending out communications across the CMIP network. 
+To sign up for it, please visit <https://wcrp-cmip.org/cmip-mailing-lists/>.
+

--- a/docs/CMIP7/Global_Attributes.md
+++ b/docs/CMIP7/Global_Attributes.md
@@ -603,6 +603,8 @@ Some of the currently existing CVs have only been partially populated. The follo
 - institution_id
 - source_id (see [Source ID Guidance](Source_ID_guidance.md) for information on constructing a new source id)
 
+How to register new values is [described here](cv_registration.md).
+
 ### Variable Identifiers
 
 The variable_id global attribute records the "root name" of a branded variable. The recognized root names can be found either in the [CMIP7 Data Request](https://cmip-data-request.github.io/cmip7-dreq-webview/variable_search.html) or the [CMOR variable tables](https://github.com/WCRP-CMIP/cmip7-cmor-tables/tree/main/tables). Further guidance on the branded variables naming scheme, which is new in CMIP7, is [available here](https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Branded_Variables/).

--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -18,7 +18,7 @@ provided as early as possible):
   without first registering your institution and model, which includes providing the
   **Essential Model Documentation (EMD)** for your model. 
   The EMD registration process is [documented here](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/). 
-  The list of institutions currently registered for CMIP7 can be [found here](https://github.com/WCRP-CMIP/CMIP7-CVs/tree/main/institution) and further details about the registered institutions are [stored here](https://github.com/WCRP-CMIP/WCRP-universe/tree/esgvoc/institution).
+  The institution registration process, and the list of already-registered institutes, are [available here](cv_registration.md#21-institution-registration).
   **Output grids for regridded data must also be registered** via an online form described in the [EMD documenation](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/) (i.e., for any grid used to report data that is not the model's native grid).
 
 [//]: # (* Following, or as part of, the registration of your models you will be able to indicate your )

--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -18,7 +18,7 @@ provided as early as possible):
   without first registering your institution and model, which includes providing the
   **Essential Model Documentation (EMD)** for your model. 
   The EMD registration process is [documented here](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/). 
-  The institution registration process, and the list of already-registered institutes, are [available here](cv_registration.md#21-institution-registration).
+  The institution registration process is [available here](cv_registration.md#21-institution-registration) (including the list of institutes that are already registered).
   **Output grids for regridded data must also be registered** via an online form described in the [EMD documenation](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/) (i.e., for any grid used to report data that is not the model's native grid).
 
 [//]: # (* Following, or as part of, the registration of your models you will be able to indicate your )

--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -17,7 +17,8 @@ provided as early as possible):
   Publication of your model output (on ESGF) will not be possible
   without first registering your institution and model, which includes providing the
   **Essential Model Documentation (EMD)** for your model. 
-  The EMD registration process is [documented here](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/) and the list of currently registered institutions can be [found here](https://github.com/WCRP-CMIP/CMIP7-CVs/tree/main/institution).
+  The EMD registration process is [documented here](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/). 
+  The list of institutions currently registered for CMIP7 can be [found here](https://github.com/WCRP-CMIP/CMIP7-CVs/tree/main/institution) and further details about the registered institutions are [stored here](https://github.com/WCRP-CMIP/WCRP-universe/tree/esgvoc/institution).
   **Output grids for regridded data must also be registered** via an online form described in the [EMD documenation](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/) (i.e., for any grid used to report data that is not the model's native grid).
 
 [//]: # (* Following, or as part of, the registration of your models you will be able to indicate your )

--- a/docs/CMIP7/Guidance_for_modellers.md
+++ b/docs/CMIP7/Guidance_for_modellers.md
@@ -12,12 +12,12 @@ General guidance is also available via the [General Guidance](General_Guidance.m
 Groups who plan to participate in CMIP7 should (in roughly this order, although model documentation should be 
 provided as early as possible):
 
-* Indicate your intention to participate by registering your institution and model with the 
-  [CMIP7 Controlled Vocabularies](https://github.com/WCRP-CMIP/CMIP7-CVs) when the registration
-  process is available. Publication of your model output (on ESGF) will not be possible
+* Indicate your intention to participate by [registering your institution and model](cv_registration.md) with the 
+  [CMIP7 Controlled Vocabularies](https://github.com/WCRP-CMIP/CMIP7-CVs). 
+  Publication of your model output (on ESGF) will not be possible
   without first registering your institution and model, which includes providing the
   **Essential Model Documentation (EMD)** for your model. 
-  The EMD registration process is [documented here](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/) and the list of currently registered institutions can be found at ***link needed***.
+  The EMD registration process is [documented here](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/) and the list of currently registered institutions can be [found here](https://github.com/WCRP-CMIP/CMIP7-CVs/tree/main/institution).
   **Output grids for regridded data must also be registered** via an online form described in the [EMD documenation](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/) (i.e., for any grid used to report data that is not the model's native grid).
 
 [//]: # (* Following, or as part of, the registration of your models you will be able to indicate your )

--- a/docs/CMIP7/Guidance_for_users.md
+++ b/docs/CMIP7/Guidance_for_users.md
@@ -12,6 +12,7 @@ This page is designed to inform users of climate model outputs on key CMIP7 conc
     An overview of **how to access and use CMIP data** is given in the slides from [CMIP 2026 workshop WIP session](https://zenodo.org/records/18934629) (slides 3-20).
 
 General guidance is also available via the [General Guidance](General_Guidance.md) page.
+To sign up for the CMIP Community News mailing list please visit <https://wcrp-cmip.org/cmip-mailing-lists/>.
 
 ## 1.  Accessing CMIP7 data
 


### PR DESCRIPTION
Guidance for Modellers near top said "Indicate your intention to participate by registering your institution and model ... when the registration process is available", so this just updates that to point to the CVs registration page. Also on Global Attributes where addition of new values to CVs is mentioned.

Unrelated but also noticed a couple places where links to community maillist signup could be useful, so added those. @bethdingley 